### PR TITLE
feat: add kernel lifecycle hooks

### DIFF
--- a/packages/core/src/kernel.ts
+++ b/packages/core/src/kernel.ts
@@ -1,8 +1,13 @@
 import { Application } from './application';
-import { LifecyclePhase } from './lifecycle';
+import { LifecyclePhase, LifecycleHook } from './lifecycle';
+
+type KernelHookMap = Map<LifecyclePhase, LifecycleHook[]>;
 
 export class Kernel {
   private readonly app: Application;
+
+  private readonly beforeHooks: KernelHookMap = new Map();
+  private readonly afterHooks: KernelHookMap = new Map();
 
   constructor(app?: Application) {
     this.app = app ?? new Application();
@@ -12,19 +17,47 @@ export class Kernel {
     return this.app;
   }
 
+  onBefore(phase: LifecyclePhase, hook: LifecycleHook): void {
+    const hooks = this.beforeHooks.get(phase) ?? [];
+    hooks.push(hook);
+    this.beforeHooks.set(phase, hooks);
+  }
+
+  onAfter(phase: LifecyclePhase, hook: LifecycleHook): void {
+    const hooks = this.afterHooks.get(phase) ?? [];
+    hooks.push(hook);
+    this.afterHooks.set(phase, hooks);
+  }
+
+  private async runHooks(
+    hooks: KernelHookMap,
+    phase: LifecyclePhase
+  ): Promise<void> {
+    const list = hooks.get(phase) ?? [];
+    for (const hook of list) {
+      await hook();
+    }
+  }
+
+  private async runPhase(phase: LifecyclePhase): Promise<void> {
+    await this.runHooks(this.beforeHooks, phase);
+    await this.app.runPhase(phase);
+    await this.runHooks(this.afterHooks, phase);
+  }
+
   async boot(): Promise<void> {
-    await this.app.runPhase(LifecyclePhase.Initialize);
-    await this.app.runPhase(LifecyclePhase.LoadConfig);
-    await this.app.runPhase(LifecyclePhase.RegisterModules);
-    await this.app.runPhase(LifecyclePhase.PrepareRuntime);
+    await this.runPhase(LifecyclePhase.Initialize);
+    await this.runPhase(LifecyclePhase.LoadConfig);
+    await this.runPhase(LifecyclePhase.RegisterModules);
+    await this.runPhase(LifecyclePhase.PrepareRuntime);
   }
 
   async execute(): Promise<void> {
-    await this.app.runPhase(LifecyclePhase.Execute);
+    await this.runPhase(LifecyclePhase.Execute);
   }
 
   async shutdown(): Promise<void> {
-    await this.app.runPhase(LifecyclePhase.Shutdown);
+    await this.runPhase(LifecyclePhase.Shutdown);
   }
 
   async run(): Promise<void> {

--- a/packages/core/src/lifecycle.ts
+++ b/packages/core/src/lifecycle.ts
@@ -8,3 +8,5 @@ export enum LifecyclePhase {
 }
 
 export type LifecycleHook = () => void | Promise<void>;
+
+export type KernelHookTiming = 'before' | 'after';


### PR DESCRIPTION
## What does this PR do?

Adds kernel-level lifecycle hooks to NorevelJS.

This allows logic to run before and after each lifecycle phase
while keeping the application lifecycle contract enforced by the kernel.

## Why is this change needed?

Kernel hooks provide a controlled extension point for future runtimes
and framework features without introducing implicit behavior.

## Breaking changes?

- [ ] Yes
- [x] No
