### PR TITLE
feat(http): implement http runtime adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: pnpm install
 
       - name: Build
-        run: pnpm run --recursive build
+        run: pnpm build
 
       - name: Test
         run: pnpm run --recursive test

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 .idea
 .vscode
 *.log
+*.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "examples/*"
   ],
   "scripts": {
-    "build": "pnpm run --recursive build",
-    "clean": "pnpm run --recursive clean",
-    "lint": "pnpm run --recursive lint",
-    "test": "pnpm run --recursive test"
+    "build": "pnpm exec tsc -b",
+    "clean": "pnpm exec tsc -b --clean",
+    "lint": "echo \"lint placeholder\"",
+    "test": "echo \"test placeholder\""
   },
   "devDependencies": {
+    "@types/node": "^25.1.0",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src"]
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src"]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "clean": "rm -rf dist",
-    "lint": "echo \"lint placeholder\"",
-    "test": "echo \"test placeholder\""
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "composite": true
   },
   "include": ["src"]
 }

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -9,5 +9,8 @@
     "clean": "rm -rf dist",
     "lint": "echo \"lint placeholder\"",
     "test": "echo \"test placeholder\""
+  },
+  "dependencies": {
+    "@norevel/core": "workspace:*"
   }
 }

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -1,1 +1,3 @@
-export {}
+export { HttpServer } from './server';
+export { HttpRuntime } from './runtime';
+export type { HttpContext } from './types';

--- a/packages/http/src/runtime.ts
+++ b/packages/http/src/runtime.ts
@@ -1,0 +1,20 @@
+import { Kernel } from '@norevel/core';
+import { HttpContext } from './types';
+
+export class HttpRuntime {
+  private readonly kernel: Kernel;
+
+  constructor(kernel: Kernel) {
+    this.kernel = kernel;
+  }
+
+  async handle(context: HttpContext): Promise<void> {
+    // Future: attach context to execution scope
+    // For now: lifecycle execution only
+    await this.kernel.execute();
+
+    // Default response (placeholder)
+    context.response.statusCode = 200;
+    context.response.end('OK');
+  }
+}

--- a/packages/http/src/server.ts
+++ b/packages/http/src/server.ts
@@ -1,0 +1,36 @@
+import http from 'http';
+import { Kernel } from '@norevel/core';
+import { HttpRuntime } from './runtime';
+import { HttpContext } from './types';
+
+export interface HttpServerOptions {
+  port: number;
+}
+
+export class HttpServer {
+  private readonly kernel: Kernel;
+  private readonly runtime: HttpRuntime;
+
+  constructor(kernel: Kernel) {
+    this.kernel = kernel;
+    this.runtime = new HttpRuntime(kernel);
+  }
+
+  listen(options: HttpServerOptions): void {
+    const server = http.createServer(async (req, res) => {
+      const context: HttpContext = {
+        request: req,
+        response: res
+      };
+
+      try {
+        await this.runtime.handle(context);
+      } catch (error) {
+        res.statusCode = 500;
+        res.end('Internal Server Error');
+      }
+    });
+
+    server.listen(options.port);
+  }
+}

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -1,0 +1,6 @@
+import { IncomingMessage, ServerResponse } from 'http';
+
+export interface HttpContext {
+  request: IncomingMessage;
+  response: ServerResponse;
+}

--- a/packages/http/tsconfig.json
+++ b/packages/http/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    { "path": "../core" }
+  ],
   "include": ["src"]
 }

--- a/packages/orm/tsconfig.json
+++ b/packages/orm/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src"]
 }

--- a/packages/queue/tsconfig.json
+++ b/packages/queue/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@types/node':
+        specifier: ^25.1.0
+        version: 25.1.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -18,7 +21,11 @@ importers:
 
   packages/core: {}
 
-  packages/http: {}
+  packages/http:
+    dependencies:
+      '@norevel/core':
+        specifier: workspace:*
+        version: link:../core
 
   packages/orm: {}
 
@@ -26,11 +33,23 @@ importers:
 
 packages:
 
+  '@types/node@25.1.0':
+    resolution: {integrity: sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
 snapshots:
 
+  '@types/node@25.1.0':
+    dependencies:
+      undici-types: 7.16.0
+
   typescript@5.9.3: {}
+
+  undici-types@7.16.0: {}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "types": ["node"],
     "declaration": true,
     "strict": true,
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "packages/core" },
+    { "path": "packages/http" }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Implements the HTTP runtime adapter for NorevelJS.

This includes:
- A minimal Node.js HTTP server
- An HTTP runtime adapter that triggers kernel execution
- A reserved execution context for future expansion

No routing, controllers, or middleware are included.

## Why is this change needed?

This establishes HTTP as a runtime trigger while preserving the
framework’s lifecycle-driven architecture.

## Breaking changes?

- [ ] Yes
- [x] No
