### PR TITLE
feat(http): add minimal routing support

### DIFF
--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -1,3 +1,3 @@
 export { HttpServer } from './server';
-export { HttpRuntime } from './runtime';
-export type { HttpContext } from './types';
+export { Router } from './router';
+export type { HttpContext, RouteHandler } from './types';

--- a/packages/http/src/router.ts
+++ b/packages/http/src/router.ts
@@ -1,0 +1,31 @@
+import { IncomingMessage } from 'http';
+import { RouteHandler } from './types';
+
+type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+interface Route {
+  method: Method;
+  path: string;
+  handler: RouteHandler;
+}
+
+export class Router {
+  private routes: Route[] = [];
+
+  add(method: Method, path: string, handler: RouteHandler): void {
+    this.routes.push({ method, path, handler });
+  }
+
+  match(req: IncomingMessage): RouteHandler | null {
+    const method = req.method as Method | undefined;
+    const url = req.url;
+
+    if (!method || !url) return null;
+
+    const route = this.routes.find(
+      r => r.method === method && r.path === url
+    );
+
+    return route?.handler ?? null;
+  }
+}

--- a/packages/http/src/runtime.ts
+++ b/packages/http/src/runtime.ts
@@ -1,20 +1,27 @@
 import { Kernel } from '@norevel/core';
 import { HttpContext } from './types';
+import { Router } from './router';
 
 export class HttpRuntime {
   private readonly kernel: Kernel;
+  private readonly router: Router;
 
-  constructor(kernel: Kernel) {
+  constructor(kernel: Kernel, router: Router) {
     this.kernel = kernel;
+    this.router = router;
   }
 
   async handle(context: HttpContext): Promise<void> {
-    // Future: attach context to execution scope
-    // For now: lifecycle execution only
     await this.kernel.execute();
 
-    // Default response (placeholder)
-    context.response.statusCode = 200;
-    context.response.end('OK');
+    const handler = this.router.match(context.request);
+
+    if (!handler) {
+      context.response.statusCode = 404;
+      context.response.end('Not Found');
+      return;
+    }
+
+    await handler(context);
   }
 }

--- a/packages/http/src/server.ts
+++ b/packages/http/src/server.ts
@@ -1,6 +1,7 @@
 import http from 'http';
 import { Kernel } from '@norevel/core';
 import { HttpRuntime } from './runtime';
+import { Router } from './router';
 import { HttpContext } from './types';
 
 export interface HttpServerOptions {
@@ -9,23 +10,22 @@ export interface HttpServerOptions {
 
 export class HttpServer {
   private readonly kernel: Kernel;
+  private readonly router: Router;
   private readonly runtime: HttpRuntime;
 
-  constructor(kernel: Kernel) {
+  constructor(kernel: Kernel, router: Router) {
     this.kernel = kernel;
-    this.runtime = new HttpRuntime(kernel);
+    this.router = router;
+    this.runtime = new HttpRuntime(kernel, router);
   }
 
   listen(options: HttpServerOptions): void {
     const server = http.createServer(async (req, res) => {
-      const context: HttpContext = {
-        request: req,
-        response: res
-      };
+      const context: HttpContext = { request: req, response: res };
 
       try {
         await this.runtime.handle(context);
-      } catch (error) {
+      } catch {
         res.statusCode = 500;
         res.end('Internal Server Error');
       }

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -4,3 +4,5 @@ export interface HttpContext {
   request: IncomingMessage;
   response: ServerResponse;
 }
+
+export type RouteHandler = (context: HttpContext) => void | Promise<void>;


### PR DESCRIPTION
## What does this PR do?

Adds minimal HTTP routing support to NorevelJS.

This introduces:
- A simple method/path router
- Handler-based request processing
- Kernel-safe execution flow

No controllers, middleware, or DI are included.

## Why is this change needed?

Routing is required to demonstrate HTTP request handling
while preserving the framework’s lifecycle-driven design.

## Breaking changes?

- [ ] Yes
- [x] No
