### PR TITLE
feat(core): implement queue workers with lifecycle and CLI integration

### DIFF
--- a/packages/cli/src/commands/queue-work.ts
+++ b/packages/cli/src/commands/queue-work.ts
@@ -1,0 +1,22 @@
+import { CliCommand } from '../command';
+import { Worker, InMemoryQueueDriver } from '@norevel/core';
+
+export const queueWorkCommand: CliCommand = {
+  name: 'queue:work',
+  description: 'Start queue worker',
+
+  async execute({ kernel, args }) {
+    const queue = args[0] ?? 'default';
+
+    const driver = kernel
+      .getApplication()
+      .getContainer()
+      .resolve(InMemoryQueueDriver);
+
+    const worker = new Worker(kernel, driver, {
+      queue
+    });
+
+    await worker.start();
+  }
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,3 +5,5 @@ export type { ExecutionContext, ExecutionType } from './execution-context';
 export { Config } from './config/config';
 export { Environment } from './config/environment';
 export { ConfigLoader } from './config/config-loader';
+export * from './queue';
+export * from './job';

--- a/packages/core/src/job/index.ts
+++ b/packages/core/src/job/index.ts
@@ -1,4 +1,3 @@
 export { Job } from './job';
 export { JobRunner } from './job-runner';
-export { QueueDriver } from './queue-driver';
 export { JobContext } from './job-context';

--- a/packages/core/src/queue/in-memory-driver.ts
+++ b/packages/core/src/queue/in-memory-driver.ts
@@ -1,0 +1,20 @@
+import { QueueDriver, QueuePayload } from './queue-driver';
+
+export class InMemoryQueueDriver implements QueueDriver {
+  private queues: Map<string, QueuePayload[]> = new Map();
+
+  async push(queue: string, payload: QueuePayload): Promise<void> {
+    const list = this.queues.get(queue) ?? [];
+    list.push(payload);
+    this.queues.set(queue, list);
+  }
+
+  async pop(queue: string): Promise<QueuePayload | null> {
+    const list = this.queues.get(queue);
+    if (!list || list.length === 0) {
+      return null;
+    }
+
+    return list.shift() ?? null;
+  }
+}

--- a/packages/core/src/queue/index.ts
+++ b/packages/core/src/queue/index.ts
@@ -1,0 +1,5 @@
+export * from './queue-driver';
+export * from './in-memory-driver';
+export * from './queue-manager';
+export * from './worker';
+export * from './worker-options';

--- a/packages/core/src/queue/queue-driver.ts
+++ b/packages/core/src/queue/queue-driver.ts
@@ -1,0 +1,12 @@
+export interface QueuePayload {
+  job: string;
+  data: any;
+  attempt: number;
+  availableAt: number;
+  queue: string;
+}
+
+export interface QueueDriver {
+  push(queue: string, payload: QueuePayload): Promise<void>;
+  pop(queue: string): Promise<QueuePayload | null>;
+}

--- a/packages/core/src/queue/queue-manager.ts
+++ b/packages/core/src/queue/queue-manager.ts
@@ -1,0 +1,16 @@
+import { QueueDriver } from './queue-driver';
+import { Job } from '../job/job';
+
+export class QueueManager {
+  constructor(private readonly driver: QueueDriver) {}
+
+  async dispatch(job: Job, queue = 'default'): Promise<void> {
+    await this.driver.push(queue, {
+      job: job.constructor.name,
+      data: job,
+      attempt: 0,
+      availableAt: Date.now() + job.delay,
+      queue
+    });
+  }
+}

--- a/packages/core/src/queue/worker-options.ts
+++ b/packages/core/src/queue/worker-options.ts
@@ -1,0 +1,5 @@
+export interface WorkerOptions {
+  queue?: string;
+  sleep?: number;
+  maxTries?: number;
+}

--- a/packages/core/src/queue/worker.ts
+++ b/packages/core/src/queue/worker.ts
@@ -1,0 +1,87 @@
+import { Kernel } from '../kernel';
+import { QueueDriver, QueuePayload } from './queue-driver';
+import { WorkerOptions } from './worker-options';
+import { Job } from '../job/job';
+import { JobContext } from '../job/job-context';
+
+export class Worker {
+  private running = false;
+
+  constructor(
+    private readonly kernel: Kernel,
+    private readonly driver: QueueDriver,
+    private readonly options: WorkerOptions = {}
+  ) {}
+
+  async start(): Promise<void> {
+    this.running = true;
+
+    console.log(`Worker started (queue: ${this.options.queue ?? 'default'})`);
+
+    process.on('SIGINT', async () => {
+      console.log('\nGracefully shutting down worker...');
+      this.running = false;
+    });
+
+    while (this.running) {
+      await this.cycle();
+    }
+
+    console.log('Worker stopped.');
+  }
+
+  private async cycle(): Promise<void> {
+    const queue = this.options.queue ?? 'default';
+    const sleep = this.options.sleep ?? 1000;
+
+    const payload = await this.driver.pop(queue);
+
+    if (!payload) {
+      await this.sleep(sleep);
+      return;
+    }
+
+    if (payload.availableAt > Date.now()) {
+      await this.sleep(500);
+      return;
+    }
+
+    await this.process(payload);
+  }
+
+  private async process(payload: QueuePayload) {
+    const job: Job = payload.data;
+    const maxTries = this.options.maxTries ?? job.retries;
+
+    try {
+      const context = new JobContext(
+        payload.job,
+        payload.attempt
+      );
+
+      await this.kernel.execute(context);
+      await job.handle();
+
+      console.log(`Job processed: ${payload.job}`);
+    } catch (error) {
+      if (payload.attempt < maxTries) {
+        payload.attempt++;
+
+        await this.driver.push(payload.queue, {
+          ...payload,
+          availableAt: Date.now() + 1000
+        });
+
+        console.log(`Retrying job: ${payload.job}`);
+        return;
+      }
+
+      await job.failed(error as Error);
+      console.error(`Job permanently failed: ${payload.job}`);
+    }
+  }
+
+  private sleep(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+}


### PR DESCRIPTION
- Add named queue support
- Implement Worker with graceful shutdown
- Add WorkerOptions for configurability
- Introduce QueueManager
- Integrate worker with kernel execution context
- Add CLI queue:work command

## What does this PR do?

## Why is this change needed?

## Breaking changes?

- [ ] Yes
- [ ] No
